### PR TITLE
1.1.0 - lkn-recurrency-give (Correção na documentação e plugin-updater)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,15 +31,19 @@ jobs:
     - name: Make plugin root directory
       run: "mkdir $PLUGIN_NAME && mv -t ./$PLUGIN_NAME ./Admin ./Includes ./Languages ./Public *.txt *.php *.json && cp -r ./vendor ./${{env.PLUGIN_NAME}}/vendor && find ./${{env.PLUGIN_NAME}} -type f -exec chmod 0644 {} + && find ./${{env.PLUGIN_NAME}} -type d -exec chmod 0755 {} + && ls -lah"
 
-    # Compact plugin as .zip
+    # Create a specific directory and archive the plugin as .zip inside it
+    - name: Create Output Directory
+      run: mkdir -p ./dist
+
     - name: Archive Release
       uses: thedoctor0/zip-release@master
       with:
         type: 'zip'
-        path: '${{ env.PLUGIN_NAME }}'
-        directory: '.'
-        filename: '${{ env.PLUGIN_NAME }}.zip'
-        exclusions: '*.git* /*node_modules/* .editorconfig'
+        path: '${{ env.PLUGIN_NAME }}' # Caminho dos arquivos a serem compactados
+        directory: './dist' # Diretório onde o .zip será salvo
+        filename: '${{ env.PLUGIN_NAME }}.zip' # Nome do arquivo .zip
+        exclusions: '*.git* /*node_modules/* .editorconfig' # Exclusões
+
     # File upload to server via FTP
     - name: Upload .zip to server via FTP
       uses: SamKirkland/FTP-Deploy-Action@4.3.0
@@ -48,7 +52,7 @@ jobs:
         port: ${{ secrets.FTP_PORT }}
         username: ${{ secrets.FTP_USER }} # Usuário FTP
         password: ${{ secrets.FTP_PASSWORD }} # Senha FTP
-        local-dir: ./ # Diretório local onde o arquivo está
+        local-dir: ./dist/ # Diretório local onde o arquivo está
         server-dir: ./wp/ # Diretório remoto onde o arquivo será enviado
         #include: "${{ env.PLUGIN_NAME }}.zip" # Arquivo específico a ser enviado
 


### PR DESCRIPTION
# Link Nacional GiveWP Recurrency - 1.0.1

**Contribuidores:** Link Nacional

**Site:** [Link Nacional](https://www.linknacional.com.br/)

**Tags:** recorrência, give, giveWP, doações, dashboard

**Testado até:** 6.7.2

**Versão estável:** 1.1.0

**Licença:** GPLv2 ou posterior

**Tradução:** Português(Brasil) / Inglês 

## Descrição
Este plugin cria um dashboard com dados de recorrência de pagamento do GiveWP, fornecendo gráficos personalizados e informações detalhadas sobre as doações.

## Resumo(1.1.0)

> Implementação do Plugin-updater(Interno):

![image](https://github.com/user-attachments/assets/40bd6cfa-4737-4e99-9d36-bd82fd2861fc)

> Correção na documentação para lançamento(Plugin-check).

> Correção nas datas no relatório no mês de fevereiro.