### PR TITLE
1.1.0 - lkn-recurrency-give (Correção na documentação e plugin-updater)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,8 +39,8 @@ jobs:
       uses: thedoctor0/zip-release@master
       with:
         type: 'zip'
-        path: '${{ env.PLUGIN_NAME }}' # Caminho dos arquivos a serem compactados
-        directory: './dist' # Diretório onde o .zip será salvo
+        path: './${{ env.PLUGIN_NAME }}' # Caminho dos arquivos a serem compactados
+        directory: './dist/' # Diretório onde o .zip será salvo
         filename: '${{ env.PLUGIN_NAME }}.zip' # Nome do arquivo .zip
         exclusions: '*.git* /*node_modules/* .editorconfig' # Exclusões
 


### PR DESCRIPTION
# Link Nacional GiveWP Recurrency - 1.1.0

**Contribuidores:** Link Nacional

**Site:** [Link Nacional](https://www.linknacional.com.br/)

**Tags:** recorrência, give, giveWP, doações, dashboard

**Testado até:** 6.7.2

**Versão estável:** 1.1.0

**Licença:** GPLv2 ou posterior

**Tradução:** Português(Brasil) / Inglês 

## Descrição
Este plugin cria um dashboard com dados de recorrência de pagamento do GiveWP, fornecendo gráficos personalizados e informações detalhadas sobre as doações.

## Resumo(1.1.0)

> Implementação do Plugin-updater(Interno):

![image](https://github.com/user-attachments/assets/40bd6cfa-4737-4e99-9d36-bd82fd2861fc)

> Correção na documentação para lançamento(Plugin-check).

> Correção nas datas no relatório no mês de fevereiro.