### PR TITLE
1.1.0 - lkn-recurrency-give (Correção na documentação e plugin-updater) 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,10 +49,10 @@ jobs:
       uses: thedoctor0/zip-release@master
       with:
         type: 'zip'
-        path: build/${{ env.PLUGIN_NAME }}
-        directory: ./dist/
+        path: 'build/${{ env.PLUGIN_NAME }}'
+        directory: '.'
         filename: '${{ env.PLUGIN_NAME }}.zip'
-        exclusions: '*.git* /*node_modules/* .editorconfig .github'
+        exclusions: '*.git* /*node_modules/* .editorconfig'
 
     # File upload to server via FTP
     - name: Upload .zip to server via FTP


### PR DESCRIPTION
# Link Nacional GiveWP Recurrency - 1.0.1

**Contribuidores:** Link Nacional

**Site:** [Link Nacional](https://www.linknacional.com.br/)

**Tags:** recorrência, give, giveWP, doações, dashboard

**Testado até:** 6.7.2

**Versão estável:** 1.1.0

**Licença:** GPLv2 ou posterior

**Tradução:** Português(Brasil) / Inglês 

## Descrição
Este plugin cria um dashboard com dados de recorrência de pagamento do GiveWP, fornecendo gráficos personalizados e informações detalhadas sobre as doações.

## Resumo(1.1.0)

> Implementação do Plugin-updater(Interno):

![image](https://github.com/user-attachments/assets/40bd6cfa-4737-4e99-9d36-bd82fd2861fc)

> Correção na documentação para lançamento(Plugin-check).

> Correção nas datas no relatório no mês de fevereiro.