### PR TITLE
1.1.0 - lkn-recurrency-give (Correção na documentação e plugin-updater) 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,19 +31,10 @@ jobs:
     - name: Prepare plugin folder
       run: |
         mkdir -p build/${PLUGIN_NAME}
-        mv Admin Includes Languages Public *.php *.txt *.json build/${PLUGIN_NAME}/
+        mv Admin Includes Languages Public *.php *.txt *.json ./build/${PLUGIN_NAME}/
         cp -r vendor build/${PLUGIN_NAME}/vendor
-        find build/${PLUGIN_NAME} -type f -exec chmod 0644 {} +
-        find build/${PLUGIN_NAME} -type d -exec chmod 0755 {} +
-
-    # Create a specific directory and archive the plugin as .zip inside it
-    - name: Create Output Directory
-      run: mkdir -p ./dist
-
-    - name: Debug - List build contents
-      run: |
-        echo "Conteúdo de build/${PLUGIN_NAME}:"
-        ls -lah build/${PLUGIN_NAME}
+        find ./build/${PLUGIN_NAME} -type f -exec chmod 0644 {} +
+        find ./build/${PLUGIN_NAME} -type d -exec chmod 0755 {} +
 
     - name: Archive Release
       uses: thedoctor0/zip-release@master
@@ -62,7 +53,7 @@ jobs:
         port: ${{ secrets.FTP_PORT }}
         username: ${{ secrets.FTP_USER }} # Usuário FTP
         password: ${{ secrets.FTP_PASSWORD }} # Senha FTP
-        local-dir: ./dist/ # Diretório local onde o arquivo está
+        local-dir: ./build/ # Diretório local onde o arquivo está
         server-dir: ./wp/ # Diretório remoto onde o arquivo será enviado
         #include: "${{ env.PLUGIN_NAME }}.zip" # Arquivo específico a ser enviado
 


### PR DESCRIPTION
# Link Nacional GiveWP Recurrency - 1.1.0

**Contribuidores:** Link Nacional

**Site:** [Link Nacional](https://www.linknacional.com.br/)

**Tags:** recorrência, give, giveWP, doações, dashboard

**Testado até:** 6.7.2

**Versão estável:** 1.1.0

**Licença:** GPLv2 ou posterior

**Tradução:** Português(Brasil) / Inglês 

## Descrição
Este plugin cria um dashboard com dados de recorrência de pagamento do GiveWP, fornecendo gráficos personalizados e informações detalhadas sobre as doações.

## Resumo(1.1.0)

> Implementação do Plugin-updater(Interno):

![image](https://github.com/user-attachments/assets/40bd6cfa-4737-4e99-9d36-bd82fd2861fc)

> Correção na documentação para lançamento(Plugin-check).

> Correção nas datas no relatório no mês de fevereiro.